### PR TITLE
fix/FE-77: Fixed the width, spacing and typographical errors in the privacy policy page.

### DIFF
--- a/frontend/src/pages/PrivacyPolicy/Bottom.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Bottom.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { FaArrowRight } from "react-icons/fa";
+import { StyledButton } from '../../components/Styles/Body/Button.styled';
 import { StyledBottom } from './Bottom.styled';
 
 export default function Bottom() {
@@ -6,7 +9,7 @@ export default function Bottom() {
 		<StyledBottom>
 			
 			<h2>We are here to help maintain your brand's <br /> reputation. If we don't succeed you don't pay</h2>
-            <button>Get Started</button>
+            <StyledButton> <Link to='/get-a-quote'> Get a free quote <span><FaArrowRight/></span> </Link> </StyledButton>
 		</StyledBottom>
 	);
 }

--- a/frontend/src/pages/PrivacyPolicy/Bottom.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Bottom.styled.jsx
@@ -2,36 +2,46 @@ import styled from 'styled-components';
 
 export const StyledBottom = styled.div`
 	background-color: #eef1fc;
-	height: 400px;
-	margin-botoom: 20px;
-	text-align: center;
+	height: 468px;
+	margin-top: 91px;
+	display: flex ;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
 
 	h2 {
-		padding-top: 30px;
-		color: #2b2c34;
-		font-size: 45px;
-		font-style: bold;
-		line-height: 66px;
-	}
-
-	button {
-		background: ${(props) => (props.outlined ? '#fff' : '#233BA9')};
-		padding: 10px 40px;
-		border-radius: 6px;
-		color: ${(props) => (props.outlined ? '#233BA9' : '#fff')};
-		border: ${(props) =>
-			props.outlined ? '1px #233BA9 solid' : '1px #233BA9 solid'};
-		font-size: 1rem;
 		font-style: normal;
-		font-weight: 400;
+		font-weight: 700;
+		font-size: 45px;
+		line-height: 66px;
 		text-align: center;
-		margin-top: 50px;
+		color: #2B2C34;
+		padding-bottom: 40px;
+	}
+
+	
+	a{
+		font-style: normal;
+		font-weight: 900;
+		font-size: 18px;
+		line-height: 24px;
+		text-align: center;
+		color: #FFFFFF;
+		display: flex;
+		width: 100%;
+		/* padding: 10px; */
+		justify-content: space-between;
+		align-items: center;
+		span{
+			padding-left: 5px;
+		}
 	}
 
 
 
-	@media (max-width: 1020px) {
-			display: none;
+	/* @media (max-width: 1020px) { */
+			/* display: none;
 	
-		{
+		{ */
+/* } */
 `;

--- a/frontend/src/pages/PrivacyPolicy/Change.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Change.jsx
@@ -1,11 +1,16 @@
-import React from 'react'
-import { StyledChange } from './Change.styled'
+import React from 'react';
+import { StyledChange } from './Change.styled';
 
 export default function Change() {
-    return (
-        <StyledChange>
-              <h3>Changes To This Privacy Policy</h3>
-            <p>FIXIT has the discretion to update this policy from time to time. The updated version will be indicated with a date as soon as it is available. Users are encouraged to check this page for changes often to be informed of how we protect your information</p>
-        </StyledChange>
-    )
+	return (
+		<StyledChange>
+			<h3>Changes To This Privacy Policy</h3>
+			<p>
+				FIXIT has the discretion to update this policy from time to time. The
+				updated version will be indicated with a date as soon as it is
+				available. Users are encouraged to check this page for changes often to
+				be informed of how we protect your information
+			</p>
+		</StyledChange>
+	);
 }

--- a/frontend/src/pages/PrivacyPolicy/Change.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Change.styled.jsx
@@ -2,11 +2,14 @@ import styled from "styled-components";
 
 
 export const StyledChange = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;

--- a/frontend/src/pages/PrivacyPolicy/Contact.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Contact.styled.jsx
@@ -2,12 +2,14 @@ import styled from "styled-components";
 
 
 export const StyledContact = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
-	margin-bottom: 50px;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;
@@ -23,9 +25,9 @@ export const StyledContact = styled.div`
 	}
 
 	@media (max-width: 320px) {
-		div {
+		/* div {
 			over-flow: hidden;
-		}
+		} */
 
 		h3 {
 			font-size: 18px;
@@ -43,8 +45,8 @@ export const StyledContact = styled.div`
 
 @media (max-width: 	1020px) {
 		
-			over-flow: hidden;
-			width: 300px;
+			/* over-flow: hidden;
+			width: 300px; */
 
 		h3 {
 			font-size: 18px;

--- a/frontend/src/pages/PrivacyPolicy/Header.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Header.styled.jsx
@@ -3,22 +3,27 @@ import styled from "styled-components";
 
 export const StyledHeader = styled.header`
 background-color: #233BA9;
-width: 100%
-height: 80px;
+width: 100%;
+margin-bottom: 89px;
+padding: 24px 0px;
+/* height: 80px; */
 
 h1 {
     color: white;
     text-align: center;
+    font-family: 'Lato';
+    font-style: normal;
+    font-weight: 700;
     font-size: 45px;
-    font-style: bold;
+    line-height: 150%;
 }
 
 @media (max-width: 1020px) {
 	h1 {
      color: white;
-     padding-top: 6px;
+     /* padding-top: 6px; */
     font-size: 24px;
     font-style: bold;
     }
-    {
+}
 `;

--- a/frontend/src/pages/PrivacyPolicy/Information.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Information.jsx
@@ -7,17 +7,21 @@ export default function Information() {
 			<h3>Information Collection</h3>
 			<p>
 				We collect personal information that you voluntarily provide to us when
-				you visit our site and express interest in obtaining information <br />
-				about our products or services. Among the personal information we may
-				collect include names, phone numbers, and email addresses. <br />
+				you visit our site and express interest in obtaining information about
+				our products or services. Among the personal information we may collect
+				include names, phone numbers, and email addresses.{' '}
+			</p>
+			<p>
 				Our collection and use of your information will remain subject to this
-				privacy policy, but we cannot guarantee your information will be <br />
+				privacy policy, but we cannot guarantee your information will be
 				absolutely secure or that unauthorized persons will not access or use
-				your personal information for improper purposes. <br />
+				your personal information for improper purposes.{' '}
+			</p>
+			<p>
 				In the event of a breach of security affecting the personal information
-				that you have provided to us, or the personal information that we <br />
-				have collected, we will take actions as required by applicable laws,
-				which might include providing you notice of such breach.
+				that you have provided to us, or the personal information that we have
+				collected, we will take actions as required by applicable laws, which
+				might include providing you notice of such breach.
 			</p>
 		</StyledInformation>
 	);

--- a/frontend/src/pages/PrivacyPolicy/Information.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Information.styled.jsx
@@ -1,11 +1,14 @@
 import styled from 'styled-components';
 
 export const StyledInformation = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;
@@ -22,9 +25,9 @@ export const StyledInformation = styled.div`
 	}
 
 	@media (max-width: 320px) {
-		div {
+		/* div {
 			over-flow: hidden;
-		}
+		} */
 
 		h3 {
 			font-size: 18px;
@@ -42,8 +45,8 @@ export const StyledInformation = styled.div`
 
 	@media (max-width: 1020px) {
 		
-			over-flow: hidden;
-			width: 300px;
+			/* over-flow: hidden;
+			width: 300px; */
 
 		h3 {
 			font-size: 18px;

--- a/frontend/src/pages/PrivacyPolicy/Policy.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Policy.jsx
@@ -1,18 +1,30 @@
-import React from 'react'
-import { StyledPolicy } from './Policy.styled'
+import React from 'react';
+import { StyledPolicy } from './Policy.styled';
 
 export default function Policy() {
-    return (
-        <StyledPolicy>
-            <h3>Our Privacy Policy</h3>
-            <p>FIXIT provides this Privacy Policy to inform you of our policies and procedures regarding the collection, use and disclosure of personal <br /> information when you use our services, such as:</p>
-         <ul>
-                <li>vist our website at [website address] or any website of ours that links to this privacy policy</li>
-                <li>Engage with us in other related ways, including sales and marketing.</li>
-         </ul>
-                <p>Reading this privacy policy will help you understand your rights and choices. Please do not use this website or our services if you do not <br /> accept these. By using this website or our services, you agree to this privacy policy.</p>
-
-            
-        </StyledPolicy>
-    )
+	return (
+		<StyledPolicy>
+			<h3>Our Privacy Policy</h3>
+			<p>
+				FIXIT provides this Privacy Policy to inform you of our policies and
+				procedures regarding the collection, use and disclosure of personal
+				information when you use our services, such as:
+			</p>
+			<ul>
+				<li>
+					Visit our website at [https://repute.hng.tech] or any website of ours that
+					links to this privacy policy
+				</li>
+				<li>
+					Engage with us in other related ways, including sales and marketing.
+				</li>
+			</ul>
+			<p>
+				Reading this privacy policy will help you understand your rights and
+				choices. Please do not use this website or our services if you do not{' '}
+				<br /> accept these. By using this website or our services, you agree to
+				this privacy policy.
+			</p>
+		</StyledPolicy>
+	);
 }

--- a/frontend/src/pages/PrivacyPolicy/Policy.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Policy.styled.jsx
@@ -1,16 +1,19 @@
 import styled from 'styled-components';
 
 export const StyledPolicy = styled.div`
-	padding-left: 25px;
+	
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
-	overflow: hidden;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;
-		line-height: 48px;
+		line-height: 150%;
 		font-weight: 700;
 		font-style: bold;
 	}
@@ -31,8 +34,8 @@ export const StyledPolicy = styled.div`
 
 	@media (max-width: 320px) {
 
-		over-flow: hidden;
-		word-break: break-all
+		/* over-flow: hidden;
+		word-break: break-all */
 		
 
 		h3 {
@@ -60,8 +63,8 @@ export const StyledPolicy = styled.div`
 
 	@media (max-width: 1020px) {
 		
-			over-flow: hidden;
-			width: 300px;
+			/* over-flow: hidden;
+			width: 300px; */
 
 		h3 {
 			font-size: 18px;
@@ -79,11 +82,12 @@ export const StyledPolicy = styled.div`
 		ul {
 			list-style: disc;
 			font-size: 12px;
-			display:flex
+			display:flex;
 			flex-wrap: wrap;
 			overflow-wrap: break;
 			line-height: 21px;
 			font-style: regular;
 		}
 	}
+
 `;

--- a/frontend/src/pages/PrivacyPolicy/Privacy.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Privacy.styled.jsx
@@ -2,11 +2,14 @@ import styled from "styled-components";
 
 
 export const StyledPrivacy = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;
@@ -31,9 +34,9 @@ export const StyledPrivacy = styled.div`
 	}
 
 	@media (max-width: 320px) {
-		div {
+		/* div {
 			over-flow: hidden;
-		}
+		} */
 
 		h3 {
 			font-size: 18px;
@@ -60,8 +63,8 @@ export const StyledPrivacy = styled.div`
 
 	@media (max-width: 1020px) {
 		
-			over-flow: hidden;
-			width: 300px;
+			/* over-flow: hidden;
+			width: 300px; */
 
 		h3 {
 			font-size: 18px;
@@ -79,7 +82,7 @@ export const StyledPrivacy = styled.div`
 		ul {
 			list-style: disc;
 			font-size: 12px;
-			display:flex
+			display:flex;
 			flex-wrap: wrap;
 			overflow-wrap: break;
 			line-height: 21px;

--- a/frontend/src/pages/PrivacyPolicy/Process.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Process.jsx
@@ -1,24 +1,54 @@
-import React from 'react'
-import { StyledProcess } from './Process.styled'
-
+import React from 'react';
+import { StyledProcess } from './Process.styled';
 
 export default function Process() {
-    return (
-        <StyledProcess>
-            <h3>How We Process Information</h3>
-            <p>  We process your personal information for a variety of reasons, depending on how you interact with our services, including:</p>
-            < ul>
-                <li>To facilitate account creation and manage users' accounts: We may process your      <br /> information so you can create and log in to your account as well as keep your account in order</li>
-                
-                 <li>To deliver and facilitate the delivery of services to the user: We may process your information to provide you with the requested service.</li>
-                 <li> To respond to user inquiries: We may process your information to respond to your inquiries and solve any issues you might have with the requested service.</li>
-                
-               <li> To fulfil and manage your tickets: We may process your information to fulfil and manage your tickets made through the services.</li>
-                 <li> To request feedback: We may process your information when necessary to request feedback and contact you about your use of our service.</li>
-                <li>To send you marketing and promotional content: We may process your information for marketing purposes. You can opt-out of our<br /> marketing emails at any time.</li>
-                    <li>To protect an individual's vital interest: We may process your information to save or protect an individual's interest, such as prevent harm</li>
-                    </ul>
-            
-        </StyledProcess>
-    )
+	return (
+		<StyledProcess>
+			<h3>How We Process Information</h3>
+			<p>
+				{' '}
+				We process your personal information for a variety of reasons, depending
+				on how you interact with our services, including:
+			</p>
+			<ul>
+				<li>
+					To facilitate account creation and manage users' accounts: We may
+					process your information so you can create and log in to your
+					account as well as keep your account in order
+				</li>
+
+				<li>
+					To deliver and facilitate the delivery of services to the user: We may
+					process your information to provide you with the requested service.
+				</li>
+				<li>
+					{' '}
+					To respond to user inquiries: We may process your information to
+					respond to your inquiries and solve any issues you might have with the
+					requested service.
+				</li>
+
+				<li>
+					{' '}
+					To fulfil and manage your tickets: We may process your information to
+					fulfil and manage your tickets made through the services.
+				</li>
+				<li>
+					{' '}
+					To request feedback: We may process your information when necessary to
+					request feedback and contact you about your use of our service.
+				</li>
+				<li>
+					To send you marketing and promotional content: We may process your
+					information for marketing purposes. You can opt-out of our
+					<br /> marketing emails at any time.
+				</li>
+				<li>
+					To protect an individual's vital interest: We may process your
+					information to save or protect an individual's interest, such as
+					prevent harm
+				</li>
+			</ul>
+		</StyledProcess>
+	);
 }

--- a/frontend/src/pages/PrivacyPolicy/Process.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Process.styled.jsx
@@ -2,11 +2,14 @@ import styled from "styled-components";
 
 
 export const StyledProcess = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;
@@ -30,9 +33,9 @@ export const StyledProcess = styled.div`
 	}
 
 	@media (max-width: 320px) {
-		div {
+		/* div {
 			over-flow: hidden;
-		}
+		} */
 
 		h3 {
 			font-size: 18px;
@@ -59,8 +62,8 @@ export const StyledProcess = styled.div`
 
 	@media (max-width: 1020px) {
 		
-			over-flow: hidden;
-			width: 300px;
+			/* over-flow: hidden;
+			width: 300px; */
 
 		h3 {
 			font-size: 18px;
@@ -78,7 +81,7 @@ export const StyledProcess = styled.div`
 		ul {
 			list-style: disc;
 			font-size: 12px;
-			display:flex
+			display:flex;
 			flex-wrap: wrap;
 			overflow-wrap: break;
 			line-height: 21px;

--- a/frontend/src/pages/PrivacyPolicy/Retention.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Retention.jsx
@@ -1,18 +1,27 @@
-import React from 'react'
-import { StyledRetention } from './Retention.styled'
-
+import React from 'react';
+import { StyledRetention } from './Retention.styled';
 
 export default function Retention() {
-    return (
+	return (
+		<StyledRetention>
+			<h3>Retention and deletion of information</h3>
+			<p>
+				We will only keep your information for as long as it is necessary for
+				the purposes set out in this privacy notice unless a longer retention
+				period is requested. No purpose in this notice will require us keeping
+				your personal information for longer than the period of time a user has
+				an account with us.
+			</p>
 
-        <StyledRetention>
-            <h3>Retention and deletion of information</h3>
-            <p>We will only keep your information for as long as it is necessary for the purposes set out in this privacy notice unless a longer retention<br /> period is requested. No purpose in this notice will require us keeping your personal information for longer than the period of time a user has an account with us.  <br />
-                    You may request to access, update, correct, or delete most of your personal information through the site. We will promptly take action in response to your request, but we only retain information for as long as;</p>
-                <ul>
-                <li>You use our services and maintain an account</li>
-                <li>We have a legitimate reason to do so</li>
-            </ul>
-        </StyledRetention>
-    )
+			<p>
+				You may request to access, update, correct, or delete most of your
+				personal information through the site. We will promptly take action in
+				response to your request, but we only retain information for as long as;
+			</p>
+			<ul>
+				<li>You use our services and maintain an account</li>
+				<li>We have a legitimate reason to do so</li>
+			</ul>
+		</StyledRetention>
+	);
 }

--- a/frontend/src/pages/PrivacyPolicy/Retention.styled.jsx
+++ b/frontend/src/pages/PrivacyPolicy/Retention.styled.jsx
@@ -2,11 +2,14 @@ import styled from "styled-components";
 
 
 export const StyledRetention = styled.div`
-	padding-left: 25px;
 	color: #2b2c34;
-	padding-top: 20px;
-	width: 1000px;
-	margin: auto;
+	max-width: 75%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 10px;
+	margin: 0px auto;
+	/* outline: 1px solid red; */
 
 	h3 {
 		font-size: 32px;


### PR DESCRIPTION
This Pull Request achieves the following:

- Fixed the spacing issues on the privacy policy page by adjusting the width of the contents.
- Fixed the button, redesigned it to match the given design
- Scanned and Corrected the typographical errors that was found on the privacy policy page

Linear Link: https://linear.app/team-socket/issue/FRO-77/privacy-policy-page

Old Design:
![Screenshot (69)](https://user-images.githubusercontent.com/60774343/204681826-bb3f9804-8feb-4a46-83b3-54da09ad05f3.png)
![Screenshot (70)](https://user-images.githubusercontent.com/60774343/204681827-2a15258a-c232-4753-9d13-2a0072f31a4d.png)
![Screenshot (71)](https://user-images.githubusercontent.com/60774343/204681830-d3b5800c-01c1-436f-80f2-7542679f1f9b.png)

New Corrections:
![Screenshot (72)](https://user-images.githubusercontent.com/60774343/204681887-a83922e6-c545-42f3-b8f9-fabb9c6bdb07.png)
![Screenshot (73)](https://user-images.githubusercontent.com/60774343/204681892-0948e4e3-9e52-4372-bf1b-d44f3efdf5c6.png)
![Screenshot (74)](https://user-images.githubusercontent.com/60774343/204681893-ae83b34e-3dca-406e-a8d8-01bcaf25b08b.png)
![Screenshot (75)](https://user-images.githubusercontent.com/60774343/204681894-196b0d69-0196-473b-8b17-01d214e0ff4f.png)

