### PR TITLE
Feat/fe 114 nav and footer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
 		"web-vitals": "^2.1.4"
 	},
 	"scripts": {
-		"start": "PORT=3150 react-scripts start",
+		"start": " react-scripts start",
 		"build": "react-scripts build",
 		"test": "jest",
 		"coverage": "jest --coverage"

--- a/frontend/src/components/Layout/Header.jsx
+++ b/frontend/src/components/Layout/Header.jsx
@@ -16,15 +16,7 @@ const Header = () => {
 	const loggedin = localStorage.getItem('auth');
 
 	return (
-		<header
-			style={{
-				width: '100vw',
-				position: 'fixed',
-				top: '0',
-				backgroundColor: '#ffffff',
-				zIndex: '5',
-			}}
-		>
+		<StyledHeader>
 			<StyledContainer>
 				<StyledNav className="">
 					<img src={Logo} alt="Repute" className="logo" />
@@ -48,12 +40,14 @@ const Header = () => {
 						>
 							About Us
 						</NavLink>
-						{/* <NavLink
+						{/*
+						<NavLink
 							to="/pricing"
 							className={currentRoute === '/pricing' ? 'active' : ''}
 						>
 							Pricing
-						</NavLink> */}
+						</NavLink>
+					*/}
 						<NavLink
 							to="/contact"
 							className={currentRoute === '/contact' ? 'active' : ''}
@@ -86,11 +80,11 @@ const Header = () => {
 							Contact
 						</NavLink>
 
-						{loggedin ? 
+						{loggedin ? (
 							<StyledNavButton onClick={() => router('/dashboard')}>
 								Dashboard
 							</StyledNavButton>
-						:
+						) : (
 							<>
 								<StyledNavButton onClick={() => router('/login')}>
 									Login
@@ -100,7 +94,7 @@ const Header = () => {
 									Sign up
 								</StyledNavButton>
 							</>
-						}
+						)}
 					</ul>
 
 					{loggedin ? (
@@ -124,7 +118,7 @@ const Header = () => {
 					)}
 				</StyledNav>
 			</StyledContainer>
-		</header>
+		</StyledHeader>
 	);
 };
 const StyledNavButton = styled.button`
@@ -166,11 +160,11 @@ const StyledNav = styled.nav`
 			padding: 6px 18px;
 		}
 	}
-	.navButtons{
+	.navButtons {
 		display: flex;
 	}
 	@media screen and (max-width: 900px) {
-		.navButtons{
+		.navButtons {
 			display: none;
 		}
 	}
@@ -186,7 +180,7 @@ const StyledNav = styled.nav`
 			left: 18px;
 			cursor: pointer;
 		}
-		.navLinks{
+		.navLinks {
 			display: none;
 		}
 	}
@@ -207,6 +201,16 @@ const NavLink = styled(Link)`
 
 	&:hover {
 		color: #233ba9;
+	}
+`;
+const StyledHeader = styled.header`
+	width: 100vw;
+	position: fixed;
+	top: 0;
+	background-color: #ffffff;
+	z-index: 5;
+	@media (max-width: 900px) {
+		opacity: 0.8;
 	}
 `;
 

--- a/frontend/src/components/Reusables/FooterComponents/FooterLinks.jsx
+++ b/frontend/src/components/Reusables/FooterComponents/FooterLinks.jsx
@@ -93,7 +93,8 @@ const StyledSubscribe = styled.div`
 	}
 `;
 
-const fHeadingClasses = 'my-1 mt-4 md:mt-0 text-2xl font-[600] text-[#F7F7F7]';
+const fHeadingClasses =
+	'my-1 mt-4 md:mt-0 text-1.3xl font-[500] text-[#F7F7F7]';
 
 const aStyle = `block pb-1 flex self-start text-[15px] hover:text-[#F16F04] font-[400] text-[#F1F3F9] text-md`;
 

--- a/frontend/src/components/Styles/Body/Container.styled.jsx
+++ b/frontend/src/components/Styles/Body/Container.styled.jsx
@@ -4,5 +4,5 @@ export const StyledContainer = Styled.div`
     max-width: 1240px;
     margin: 0 auto;
 
-`;
 
+`;

--- a/frontend/src/components/Support/Article.jsx
+++ b/frontend/src/components/Support/Article.jsx
@@ -1,32 +1,38 @@
 import React from 'react';
+
 import { article } from './data';
+
 import { StyledArticle } from './Support.styled';
 
 const Article = () => {
 	return (
-		<StyledArticle data-testid="article-element">
-			<div className="article">
-				<div className="content flex justify-between">
-					{article.map(({ icon, title, text, link }, index) => {
-						return (
-							<div key={index}>
-								<div className="testimonial md:px-3 w-full md:w-1/2 lg:w-1/3 ">
-									<div className="card">
-										<div className="">
+		<>
+			<div></div>
+
+			<StyledArticle data-testid="article-element">
+				<div className="article">
+					<div className="content flex justify-between">
+						{article.map(({ icon, title, text, link }, index) => {
+							return (
+								<div key={index}>
+									<div className="testimonial md:px-3 w-full md:w-1/2 lg:w-1/3 ">
+										<div className="card">
 											<div className="">
-												<img src={icon} alt="icon" />
-												<a href={link}>{title}</a>
+												<div className="">
+													<img src={icon} alt="icon" />
+													<a href={link}>{title}</a>
+												</div>
 											</div>
+											<p className="">{text}</p>
 										</div>
-										<p className="">{text}</p>
 									</div>
 								</div>
-							</div>
-						);
-					})}
+							);
+						})}
+					</div>
 				</div>
-			</div>
-		</StyledArticle>
+			</StyledArticle>
+		</>
 	);
 };
 

--- a/frontend/src/components/Support/Hero.jsx
+++ b/frontend/src/components/Support/Hero.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { HeroSection, HeroTextDiv, StyledSupportForm } from './Support.styled';
 import searchBtn from '../../assets/images/Dashboard/search.svg';
+
 import { StyledH1Center } from '../../components/Styles/Body/Text.styled';
 
 const Hero = () => {
@@ -13,7 +15,6 @@ const Hero = () => {
 					respond to you shortly and swiftly.
 				</p>
 			</HeroTextDiv>
-
 			<StyledSupportForm>
 				<img src={searchBtn} alt="search" />
 				<input type="search" placeholder="Search for articles..." />


### PR DESCRIPTION
this pr remove the pricing link there since the page is not available, On the mobile design, replicates  the “removify” mobile navbar and reduce the fonts of the ‘Explore’ and ‘Link’ texts on the footer.
linear-link: https://linear.app/team-repute/issue/FRO-114/navigation-bar-menu-and-footer